### PR TITLE
Fix Twitter Cards and Facebook Insights broken links

### DIFF
--- a/Website/index.html
+++ b/Website/index.html
@@ -502,7 +502,7 @@
                     <label for="facebookinsights">Facebook Insights</label>
                     <em id="details-facebookinsights">◄</em>
                     <ul>
-                        <li><a href="https://developers.facebook.com/docs/insights/">Facebook Insights</a></li>
+                        <li><a href="https://developers.facebook.com/docs/sharing/referral-insights">Facebook Insights</a></li>
                     </ul>
                 </li>
                 <li>

--- a/Website/index.html
+++ b/Website/index.html
@@ -494,7 +494,7 @@
                     <label for="twittercards">Twitter Cards</label>
                     <em id="details-twittercards">◄</em>
                     <ul>
-                        <li><a href="https://dev.twitter.com/docs/cards">Documentation</a></li>
+                        <li><a href="https://developer.twitter.com/en/docs/tweets/optimize-with-cards/guides/getting-started">Documentation</a></li>
                     </ul>
                 </li>
                 <li>


### PR DESCRIPTION
The Google+ link is also broken, but I wasn't sure what to update it with. Possibly this https://developers.google.com/search/docs/guides/intro-structured-data?